### PR TITLE
Fixed channel NaN issue for 5Ghz networks.

### DIFF
--- a/lib/iwlist.js
+++ b/lib/iwlist.js
@@ -43,8 +43,8 @@ function parseOutput(str, callback) {
           }
 
           // Channel, an ugly thing to get it
-          else if (_.startsWith(line.trim(), 'Frequency:')) {
-            network.channel = parseInt(_.trim(line, ' )').split(/Channel/)[1], 10);
+          else if (_.startsWith(line.trim(), 'Channel:')) {
+            network.channel = parseInt(_.trim(line, ' )').split(/:/)[1]);
           }
             
           // Another ugly thing, the signal which can have different formats, even worse als


### PR DESCRIPTION
iwlist scan returns Channel and Frequency like the following on 5Ghz networks:
Scan completed :
```
          Cell 01 - Address: 88:36:6C:94:4A:C2
                    Channel:149
                    **Frequency:5.745 GHz**
                    Quality=55/70  Signal level=-55 dBm  
                    Encryption key:on
                    ESSID:"iptime5G"
                    Bit Rates:6 Mb/s; 9 Mb/s; 12 Mb/s; 18 Mb/s; 24 Mb/s
                              36 Mb/s; 48 Mb/s; 54 Mb/s
                    Mode:Master
```

So I needed to change parsing algorithm to read channel directly from the Channel line.