### PR TITLE
Accomodate for apples elimination of BSSID from airport results

### DIFF
--- a/lib/airport.js
+++ b/lib/airport.js
@@ -22,17 +22,13 @@ function parseOutput(str, callback) {
     let lines = str.split('\n');
 
     for (let i = 1, l = lines.length; i < l; i++) {
-      let mac = lines[i].match(macRegex);
-      if (!mac) {
-        continue;
-      }
-      let macStart = lines[i].indexOf(mac[0]);
-      let elements = lines[i].substr(macStart).split(/[ ]+/);
+      if (lines[i] == '') continue;
+      let elements = lines[i].substr(51).split(/[ ]+/);
       wifis.push({
-        'ssid'   : lines[i].substr(0, macStart).trim(),
-        'mac'    : elements[0].trim(),
-        'channel': parseInt(elements[2].trim(), 10),
-        'rssi'   : parseInt(elements[1].trim(), 10)
+        'ssid'   : lines[i].substr(0,32).trim(),
+        'mac'    : lines[i].substr(33,17).trim(),
+        'channel': parseInt(elements[1].trim(), 10),
+        'rssi'   : parseInt(elements[0].trim(), 10)
       });
     }
   }

--- a/lib/airport.js
+++ b/lib/airport.js
@@ -7,8 +7,6 @@ const tool     = '/System/Library/PrivateFrameworks/Apple80211.framework/Version
 const cmdLine  = tool + ' -s';
 const detector = tool + ' -getInfo';
 
-const macRegex = /([0-9a-zA-Z]{1}[0-9a-zA-Z]{1}[:]{1}){5}[0-9a-zA-Z]{1}[0-9a-zA-Z]{1}/;
-
 /**
  * Parsing the output of airport (Mac OS X)
  * @param str output of the tool

--- a/test/airport.js
+++ b/test/airport.js
@@ -17,7 +17,7 @@ describe('airport', () => {
       assert.equal(info.length, 36);
 
       let ap = info[0];
-      assert.equal(ap.mac, '00:35:1a:90:56:03');
+      assert.equal(ap.mac, '');
       assert.equal(ap.ssid, 'OurTest');
       assert.equal(ap.rssi, -70);
       assert.strictEqual(ap.channel, 112);

--- a/test/fixtures/airport/airport01.txt
+++ b/test/fixtures/airport/airport01.txt
@@ -1,5 +1,5 @@
                             SSID BSSID             RSSI CHANNEL HT CC SECURITY (auth/unicast/group)
-                         OurTest 00:35:1a:90:56:03 -70  112     Y  CH WPA2(PSK/AES/AES) 
+                         OurTest                   -70  112     Y  CH WPA2(PSK/AES/AES) 
                           OurDev 00:35:1a:90:56:04 -70  112     Y  CH WPA2(PSK/AES/AES) 
                          PDANet1 00:35:1a:90:56:09 -70  112     Y  CH WPA2(PSK/AES/AES) 
                        TEST-Wifi 00:35:1a:90:56:0f -70  112     Y  CH WPA2(PSK/AES/AES) 


### PR DESCRIPTION
Note.  This does not get the BSSID into the information but this does at least return a non-empty array with the rest of the info.  